### PR TITLE
Modify version of remark-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jasmine-terminal-reporter": "~0.9.1",
     "istanbul": "^0.4.5",
     "rimraf": "^2.6.2",
-    "remark-cli": "~6.0.1",
+    "remark-cli": "5.0.0",
     "remark-lint": "~6.0.4",
     "mock-fs": "~4.5.0",
     "tslint": "~5.11.0",


### PR DESCRIPTION
`remark-cli 6.0.0` 内で使用している `unified` がupdateされ、`@types/unist` が追加された。
`types/unist`では typescript3の型を使用しているためビルドでエラーとなる。
上記を回避するため、remark-cli を 5.0.0へ変更。

上記のみの修正のため、セルフマージとする。